### PR TITLE
Increase DAI amount from 1000 to 10000 in LiquidateTest.t.sol

### DIFF
--- a/foundry/test/Liquidate.test.sol
+++ b/foundry/test/Liquidate.test.sol
@@ -51,8 +51,8 @@ contract LiquidateTest is Test {
         target = new Liquidate();
 
         // Approve target to spend DAI
-        deal(DAI, address(this), 1000 * 1e18);
-        dai.approve(address(target), 1000 * 1e18);
+        deal(DAI, address(this), 10000 * 1e18);
+        dai.approve(address(target), 10000 * 1e18);
     }
 
     function test_liquidate() public {


### PR DESCRIPTION
## What This PR Does

Updates the test file `LiquidateTest.t.sol` to increase the DAI amount from `1000` to `10000` in both `deal()` and `approve()` calls.

## Why This Is Needed

The test was failing due to a `Dai/insufficient-balance` error caused by the `Liquidate` contract attempting to transfer slightly more than 1000 DAI during liquidation.

Increasing the amount to 10000 ensures:
- Sufficient balance for the test contract.
- Adequate allowance for the `Liquidate` contract.
- Smooth execution of the liquidation flow without revert.

## Changes Made

```diff
- deal(DAI, address(this), 1000 * 1e18);
- dai.approve(address(target), 1000 * 1e18);
+ deal(DAI, address(this), 10000 * 1e18);
+ dai.approve(address(target), 10000 * 1e18);
